### PR TITLE
Change unsigned int to uint32_t in EwmaT

### DIFF
--- a/EwmaT.h
+++ b/EwmaT.h
@@ -16,11 +16,11 @@ public:
     /*
     * Creates a filter with a defined initial output.
     */
-    EwmaT(T alpha, unsigned int alphaScale);
+    EwmaT(T alpha, uint32_t alphaScale);
     /*
     * Creates a filter with a defined initial output.
     */
-    EwmaT(T alpha, unsigned int alphaScale, T initialOutput);
+    EwmaT(T alpha, uint32_t alphaScale, T initialOutput);
 
     void reset();
 
@@ -33,30 +33,30 @@ public:
     T filter(T input);
 
 private:
-    void init(T alpha, unsigned int alphaScale, T initialOutput);
+    void init(T alpha, uint32_t alphaScale, T initialOutput);
 
     /*
      * Smoothing factor, in range [0,alphaScale]. Higher the value - less smoothing (higher the latest reading impact).
      */
     T alpha;
     T outputScaled;
-    unsigned int alphaScale;
+    uint32_t alphaScale;
     bool hasInitial;
 };
 
 template <typename T>
-EwmaT<T>::EwmaT(T alpha, unsigned int alphaScale) {
+EwmaT<T>::EwmaT(T alpha, uint32_t alphaScale) {
     init(alpha, alphaScale, 0);
     this->hasInitial = false;
 }
 
 template <typename T>
-EwmaT<T>::EwmaT(T alpha, unsigned int alphaScale, T initialOutput) {
+EwmaT<T>::EwmaT(T alpha, uint32_t alphaScale, T initialOutput) {
     init(alpha, alphaScale, initialOutput);
 }
 
 template <typename T>
-void EwmaT<T>::init(T alpha, unsigned int alphaScale, T initialOutput) {
+void EwmaT<T>::init(T alpha, uint32_t alphaScale, T initialOutput) {
     this->alpha = alpha;
     this->alphaScale = alphaScale;
     this->outputScaled = initialOutput * alphaScale;


### PR DESCRIPTION
For portability across multiple Arduino platforms, it would be best if EwmaT used `uint32_t` internally instead of `unsigned int` as the width of the latter varies between the ESP8266 and AVRs, causing unintended behavior on AVRs which typedef `unsigned int` to `uint16_t`.

Resolves #9 