### PR TITLE
Fix example compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,17 @@ void loop()
     int raw = analogRead(A0);
     float filtered1 = adcFilter1.filter(raw);
     float filtered2 = adcFilter2.filter(raw);
-    Serial.printf("Raw=%d, Filter1=%.3f, Filter2=%.3f", raw, filtered1, filtered2);
-    
+    #if defined(ESP8266)
+      Serial.printf("Raw=%d, Filter1=%.3f, Filter2=%.3f", raw, filtered1, filtered2);
+    #else
+      Serial.print(F("Raw="));
+      Serial.print(raw);
+      Serial.print(F(", Filter1="));
+      Serial.print(filtered1);
+      Serial.print(F(", Filter2="));
+      Serial.println(filtered2);
+    #endif
+
     delay(100);
 }
 ```

--- a/examples/FilteredADC/FilteredADC.ino
+++ b/examples/FilteredADC/FilteredADC.ino
@@ -26,7 +26,16 @@ void loop()
     int raw = analogRead(A0);
     float filtered1 = adcFilter1.filter(raw);
     float filtered2 = adcFilter2.filter(raw);
-    Serial.printf("Raw=%d, Filter1=%.3f, Filter2=%.3f", raw, filtered1, filtered2);
-    
+    #if defined(ESP8266)
+      Serial.printf("Raw=%d, Filter1=%.3f, Filter2=%.3f", raw, filtered1, filtered2);
+    #else
+      Serial.print(F("Raw="));
+      Serial.print(raw);
+      Serial.print(F(", Filter1="));
+      Serial.print(filtered1);
+      Serial.print(F(", Filter2="));
+      Serial.println(filtered2);
+    #endif
+
     delay(100);
 }


### PR DESCRIPTION
This fixes the example sketch so that it will not only compile on the ESP8266, but will also compile on any other AVR board which lacks a Serial.printf function.

Resolves #5 